### PR TITLE
Update logrus import path

### DIFF
--- a/example-usage/main.go
+++ b/example-usage/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"io/ioutil"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/rogierlommers/logrus-redis-hook"
 )
 

--- a/logrus_redis.go
+++ b/logrus_redis.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/garyburd/redigo/redis"
 )
 


### PR DESCRIPTION
Logrus import path has been changed.(See [Issue ](https://github.com/meatballhat/negroni-logrus/issues/28)and [commit](https://github.com/meatballhat/negroni-logrus/pull/29) on logrus)